### PR TITLE
Use Analog namespace. Remove unnecessary pin-mode argument.

### DIFF
--- a/AnalogButtons.cpp
+++ b/AnalogButtons.cpp
@@ -1,7 +1,7 @@
 #include "AnalogButtons.h"
 #include <Arduino.h>
 
-Button::Button(uint16_t value, void (*clickFunction)(void), void (*holdFunction)(void), uint16_t holdDuration, uint16_t holdInterval) {
+Analog::Button::Button(uint16_t value, void (*clickFunction)(void), void (*holdFunction)(void), uint16_t holdDuration, uint16_t holdInterval) {
 	this->value = value;
 	this->duration = holdDuration;
 	this->interval = holdInterval;
@@ -9,21 +9,20 @@ Button::Button(uint16_t value, void (*clickFunction)(void), void (*holdFunction)
 	this->holdFunction = holdFunction;
 }
 
-AnalogButtons::AnalogButtons(uint8_t pin, uint8_t mode, uint16_t debounce, uint8_t margin) {
+Analog::Buttons::Buttons(uint8_t pin, uint16_t debounce, uint8_t margin) {
 	this->pin = pin;
 	this->debounce = debounce;
 	this->counter = 0;
 	this->margin = margin;
-	pinMode(pin, mode);
 }
 
-void AnalogButtons::add(Button button) {
+void Analog::Buttons::add(Button button) {
 	if (buttonsCount < ANALOGBUTTONS_MAX_SIZE) {
-    	buttons[buttonsCount++] = button;
-  	}
+		buttons[buttonsCount++] = button;
+	}
 }
 
-void AnalogButtons::check() {
+void Analog::Buttons::check() {
 	// In case this function gets called very frequently avoid sampling the analog pin too often: max frequency is 50Hz
 	if (millis() - time > 120) {
 		time = millis();

--- a/AnalogButtons.h
+++ b/AnalogButtons.h
@@ -33,6 +33,8 @@
 #define ANALOGBUTTONS_MAX_SIZE 8
 #endif 
 
+namespace Analog {
+
 class Button {
 public:
 	uint16_t value;
@@ -63,7 +65,7 @@ private:
 	void (*holdFunction)(void);
 };
 
-class AnalogButtons {
+class Buttons {
 private:
 	uint32_t previousMillis;
 	uint16_t debounce;
@@ -82,11 +84,13 @@ private:
 	Button* lastButtonPressed;
 
 public:
-	AnalogButtons(uint8_t pin, uint8_t mode, uint16_t debounce = 5, uint8_t margin = 10);
+	Buttons(uint8_t pin, uint16_t debounce = 5, uint8_t margin = 10);
 
 	void add(Button button);
 
 	void check();
 };
+
+} // end namespace Analog
 
 #endif

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This work is largely inspired by the AnalogButtons library available in the Ardu
 
 Contributions are welcome under the [Apache Public License version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.html).
 
-For wiring instructions please refer to the [sample schematics] (https://raw.githubusercontent.com/rlogiacco/AnalogButtons/master/schematic.png) or, if you prefer, to the [sample breadboard] (https://raw.githubusercontent.com/rlogiacco/AnalogButtons/master/breadboard.png).
+For wiring instructions please refer to the [sample schematics](https://raw.githubusercontent.com/rlogiacco/AnalogButtons/master/schematic.png) or, if you prefer, to the [sample breadboard](https://raw.githubusercontent.com/rlogiacco/AnalogButtons/master/breadboard.png).
 
 
 Usage
@@ -40,7 +40,7 @@ In its simplest form, a button definition resemble something like the following 
 void aButtonClick() {
   // do something
 }
-Button aButton = Button(512, &aButtonClick);
+Analog::Button aButton = Analog::Button(512, &aButtonClick);
 ```
 
 In its most evoluted form a button definition looks like the following.
@@ -53,7 +53,7 @@ void aButtonClick() {
 void aButtonHold() {
   // do something else
 }
-Button aButton = Button(512, &aButtonClick, &aButtonHold, 5000, 50);
+Analog::Button aButton = Analog::Button(512, &aButtonClick, &aButtonHold, 5000, 50);
 ```
 
 
@@ -67,7 +67,7 @@ Because buttons will share the same analog pin some configuration is required in
 * the `analog value margin` which takes into account slight resistance fluctuations and ADC errors transforming the button *value* into a range (defaults to 10)
 
 ```
-AnalogButtons analogButtons = AnalogButtons(A2);
+Analog::Buttons analogButtons = Analog::Buttons(A2);
 ```
 
 3. Setup


### PR DESCRIPTION
For analogRead, you don't have to specify a pin mode.

Not tested (yet). But, I wanted to get your feedback.

Since there's another Button arduino library, the namespace will allow both to be used in the same sketch.