### PR TITLE
Minimized # of casts

### DIFF
--- a/AnalogButtons.cpp
+++ b/AnalogButtons.cpp
@@ -29,7 +29,7 @@ void AnalogButtons::check() {
 		time = millis();
 		uint16_t reading = analogRead(pin);
 		for (uint8_t i = 0; i < buttonsCount; i++) {
-			if ((int)reading >= (int)buttons[i].value - margin && (int)reading <= (int)buttons[i].value + margin) {			
+			if ((int)reading >= (int)buttons[i].value - margin && reading <= buttons[i].value + margin) {			
 				
 				if (lastButtonPressed != &buttons[i]) {
 					if (++counter >= debounce) {


### PR DESCRIPTION
Reduced casting from 4 values to only the 2 on the minimum comparison. Max ADC value of 1023 shouldn't cause any problems on the max compare side.