### PR TITLE
Fix for when Analog Button value is Zero

### DIFF
--- a/AnalogButtons.cpp
+++ b/AnalogButtons.cpp
@@ -29,7 +29,7 @@ void AnalogButtons::check() {
 		time = millis();
 		uint16_t reading = analogRead(pin);
 		for (uint8_t i = 0; i < buttonsCount; i++) {
-			if (reading >= buttons[i].value - margin && reading <= buttons[i].value + margin) {
+			if ((int16_t)reading >= (int16_t)buttons[i].value - margin && reading <= buttons[i].value + margin) {
 				
 				if (lastButtonPressed != &buttons[i]) {
 					if (++counter >= debounce) {


### PR DESCRIPTION
Unless both values in an if statement are signed, the type is assumed to be unsigned. https://en.wikipedia.org/wiki/Type_conversion#Implicit_type_conversion

When the button[i].value - margin goes negative this comparison will fail because the result instead of being a "minimum" value rolls around and becomes larger than the max value. Casting these 2 values to int16_t fixes this issue. 

Using the default margin and the maximum valid button.value would result in 1033.  Since the reading value should never exceed 1023 the Max comparison and only through developer error would it exceed the capacity of the uint16_t, therefore it shouldn't have this problem.